### PR TITLE
Mdns lifetimes

### DIFF
--- a/application/squeeze2cast/cast_util.c
+++ b/application/squeeze2cast/cast_util.c
@@ -321,8 +321,8 @@ void CastPowerOff(struct sCastCtx *Ctx) {
 }
 
 /*----------------------------------------------------------------------------*/
-void CastPowerOn(struct sCastCtx *Ctx) {
-	CastConnect(Ctx);
+bool CastPowerOn(struct sCastCtx *Ctx) {
+	return CastConnect(Ctx);
 }
 
 /*----------------------------------------------------------------------------*/

--- a/application/squeeze2cast/castcore.c
+++ b/application/squeeze2cast/castcore.c
@@ -169,7 +169,6 @@ json_t *GetTimedEvent(struct sCastCtx *Ctx, uint32_t msWait) {
 bool LaunchReceiver(tCastCtx *Ctx) {
 	// try to reconnect if SSL connection is lost
 	if (!CastConnect(Ctx)) {
-		pthread_mutex_unlock(&Ctx->Mutex);
 		return false;
 	}
 

--- a/application/squeeze2cast/inc/cast_util.h
+++ b/application/squeeze2cast/inc/cast_util.h
@@ -22,7 +22,7 @@ void	CastGetStatus(struct sCastCtx *Ctx);
 void	CastGetMediaStatus(struct sCastCtx *Ctx);
 
 void 	CastPowerOff(struct sCastCtx *Ctx);
-void 	CastPowerOn(struct sCastCtx *Ctx);
+bool 	CastPowerOn(struct sCastCtx *Ctx);
 void 	CastRelease(struct sCastCtx *Ctx);
 
 void 	CastStop(struct sCastCtx *Ctx);


### PR DESCRIPTION
I was having problems with cast devices disappearing from LMS, especially when removalTimeout was 0. In particular sometimes I would see messages like this, showing a renderer be added and removed within a few milliseconds:

```
[11:59:53.857775] mDNSsearchCallback:691 ----------------- round ------------------
[11:59:53.857832] mDNSsearchCallback:694 host 192.168.10.157, srv 192.168.10.157, name Chromecast-Audio-5287504092fcc733fc2769fcc96d472d._googlecast._tc
[11:59:53.857912] AddCastDevice:961 [0xb40950]: adding renderer (Kitchen speaker) with mac CCCC-32CA5D39
[11:59:53.858151] stream_thread_init:477 [0xaa9f98] streambuf size: 524288
[11:59:53.858212] output_thread_init:616 [0xaa9f98] init output media renderer
[11:59:53.858232] decode_thread_init:168 [0xaa9f98]: init decode
[11:59:53.858367] resample_init:340 [0xaa9f98]: resampling sync recipe: 0x00, flags: 0x00, scale: 0.89, precision: 0.0, passband_end: 0.00000, stopband_
[11:59:53.858407] discover_server:826 [0xaa9f98] sending discovery
[11:59:53.858432] mDNSsearchCallback:837 [0xb40950]: removing renderer (Kitchen speaker) on timeout
```

It turned out that the same call to mDNSsearchCallback was doing both the adding and the removing, and this because there was not an active connection to the renderer (at least not yet). After this, the devices would not re-appear, because mdns thought they were still active. 

I made some modifications to the removal logic to reflect the behavior that I think was intended. Devices are removed when the mdns times out. If removalTimeout > 0 or if (removalTimeout == 0 and there is still an active connection to the device) then removal will be delayed until either the timeout expires or the connection ends, respectively. Lifetime is managed entirely inside of the mdns code. Because the mDNSSearchCallback function is only being called when mdns triggers an event (which can be rare), I added another call to periodically check whether removalTimeout has expired for some device(s). For safety, I moved the mutex around the whole function because this code will now be called from two different threads.

I've been testing the changes for the last week on my three chromecast audio devices (including one group) and it seems to be working as expected. None are disappearing, except for when they've actually been disconnected or had mdns time out.

In addition I found a mutex unlock that seemed out of place, I added a few comments that were useful for me in understanding the code and some log messages for debugging purposes. Hope these are useful, but obviously, your call on if you want to integrate them.

Many thanks.